### PR TITLE
Allow particle multiplier values between 0 and 1, add speed multiplier setting for explosion particles

### DIFF
--- a/ParticleOverdrive/Misc/ParticleConfig.cs
+++ b/ParticleOverdrive/Misc/ParticleConfig.cs
@@ -1,4 +1,4 @@
-﻿using BS_Utils.Utilities;
+using BS_Utils.Utilities;
 using Zenject;
 
 namespace ParticleOverdrive.Misc;
@@ -24,6 +24,7 @@ internal class ParticleConfig : IInitializable
     public float ExplosionParticleMultiplier { get; set; }
     public float ExplosionParticleLifetimeMultiplier { get; set; }
     public float ExplosionParticleSizeMultiplier { get; set; }
+    public float ExplosionParticleSpeedMultiplier { get; set; }
     public bool RainbowParticles { get; set; }
     public bool NoteCoreParticles { get; set; }
 
@@ -51,6 +52,7 @@ internal class ParticleConfig : IInitializable
         config.SetFloat(SectionParticles, nameof(ExplosionParticleMultiplier), ExplosionParticleMultiplier);
         config.SetFloat(SectionParticles, nameof(ExplosionParticleLifetimeMultiplier), ExplosionParticleLifetimeMultiplier);
         config.SetFloat(SectionParticles, nameof(ExplosionParticleSizeMultiplier), ExplosionParticleSizeMultiplier);
+        config.SetFloat(SectionParticles, nameof(ExplosionParticleSpeedMultiplier), ExplosionParticleSpeedMultiplier);
         config.SetBool(SectionParticles, nameof(RainbowParticles), RainbowParticles);
         config.SetBool(SectionParticles, nameof(NoteCoreParticles), NoteCoreParticles);
         config.SetFloat(SectionParticles, nameof(ClashParticleMultiplier), ClashParticleMultiplier);
@@ -72,6 +74,7 @@ internal class ParticleConfig : IInitializable
         ExplosionParticleMultiplier = config.GetFloat(SectionParticles, nameof(ExplosionParticleMultiplier), 1.0f, true);
         ExplosionParticleLifetimeMultiplier = config.GetFloat(SectionParticles, nameof(ExplosionParticleLifetimeMultiplier), 1.0f, true);
         ExplosionParticleSizeMultiplier = config.GetFloat(SectionParticles, nameof(ExplosionParticleSizeMultiplier), 1.0f, true);
+        ExplosionParticleSpeedMultiplier = config.GetFloat(SectionParticles, nameof(ExplosionParticleSpeedMultiplier), 1.0f, true);
         RainbowParticles = config.GetBool(SectionParticles, nameof(RainbowParticles), false, true);
         NoteCoreParticles = config.GetBool(SectionParticles, nameof(NoteCoreParticles), true, true);
         ClashParticleMultiplier = config.GetFloat(SectionParticles, nameof(ClashParticleMultiplier), 1.0f, true);

--- a/ParticleOverdrive/Patches/NoteCutParticlesEffectPatch.cs
+++ b/ParticleOverdrive/Patches/NoteCutParticlesEffectPatch.cs
@@ -1,4 +1,4 @@
-﻿using ParticleOverdrive.Misc;
+using ParticleOverdrive.Misc;
 using SiraUtil.Affinity;
 using UnityEngine;
 
@@ -14,15 +14,15 @@ internal class NoteCutParticlesEffectPatch : IAffinity
     }
 
     [AffinityPatch(typeof(NoteCutCoreEffectsSpawner), nameof(NoteCutCoreEffectsSpawner.Start))]
-    public void Initialize(NoteCutCoreEffectsSpawner instance)
+    public void Initialize(NoteCutCoreEffectsSpawner __instance)
     {
-        var slashMainModule = instance._noteCutParticlesEffect._sparklesPSMainModule;
+        var slashMainModule = __instance._noteCutParticlesEffect._sparklesPSMainModule;
         // default start size multiplier is 0.015
         //_log.Debug("slash startSizeMultiplier is: " + slashMain.startSizeMultiplier);
         slashMainModule.maxParticles = int.MaxValue;
         slashMainModule.startSizeMultiplier = config.SlashParticleSizeMultiplier * 0.015f;
 
-        var explosionMainModule = instance._noteCutParticlesEffect._explosionPS.main;
+        var explosionMainModule = __instance._noteCutParticlesEffect._explosionPS.main;
         // default start lifetime multiplier is 0.6
         //_log.Debug("explosion startLifetimeMultiplier is: " + explosionMain.startLifetimeMultiplier);
         // default start size multiplier is 0.015
@@ -31,7 +31,7 @@ internal class NoteCutParticlesEffectPatch : IAffinity
         explosionMainModule.startLifetimeMultiplier = config.ExplosionParticleLifetimeMultiplier * 0.6f;
         explosionMainModule.startSizeMultiplier = config.ExplosionParticleSizeMultiplier * 0.015f;
             
-        var coreMainModule = instance._noteCutParticlesEffect._explosionCorePSMainModule;
+        var coreMainModule = __instance._noteCutParticlesEffect._explosionCorePSMainModule;
         if (!config.NoteCoreParticles)
         {
             coreMainModule.startLifetimeMultiplier = 0f;

--- a/ParticleOverdrive/Patches/NoteCutParticlesEffectPatch.cs
+++ b/ParticleOverdrive/Patches/NoteCutParticlesEffectPatch.cs
@@ -27,10 +27,13 @@ internal class NoteCutParticlesEffectPatch : IAffinity
         //_log.Debug("explosion startLifetimeMultiplier is: " + explosionMain.startLifetimeMultiplier);
         // default start size multiplier is 0.015
         //_log.Debug("explosion startSizeMultiplier is: " + explosionMain.startSizeMultiplier);
+        // default start speed multiplier is 10
+        //_log.Debug("explosion startSpeedMultiplier is: " + explosionMain.startSpeedMultiplier);
         explosionMainModule.maxParticles = int.MaxValue;
         explosionMainModule.startLifetimeMultiplier = config.ExplosionParticleLifetimeMultiplier * 0.6f;
         explosionMainModule.startSizeMultiplier = config.ExplosionParticleSizeMultiplier * 0.015f;
-            
+        explosionMainModule.startSpeedMultiplier = config.ExplosionParticleSpeedMultiplier * 10f;
+
         var coreMainModule = __instance._noteCutParticlesEffect._explosionCorePSMainModule;
         if (!config.NoteCoreParticles)
         {

--- a/ParticleOverdrive/Patches/ObstacleSaberSparkleEffectPatch.cs
+++ b/ParticleOverdrive/Patches/ObstacleSaberSparkleEffectPatch.cs
@@ -14,9 +14,9 @@ internal class ObstacleSaberSparkleEffectPatch : IAffinity
     }
 
     [AffinityPatch(typeof(ObstacleSaberSparkleEffect), nameof(ObstacleSaberSparkleEffect.Awake))]
-    public void Postfix(ObstacleSaberSparkleEffect instance)
+    public void Postfix(ObstacleSaberSparkleEffect __instance)
     {
-        var sparkleParticles = instance._sparkleParticleSystem;
+        var sparkleParticles = __instance._sparkleParticleSystem;
         var sparkleEmission = sparkleParticles.emission;
         var sparkleMainModule = sparkleParticles.main;
 

--- a/ParticleOverdrive/Patches/SaberClashEffectPatch.cs
+++ b/ParticleOverdrive/Patches/SaberClashEffectPatch.cs
@@ -15,13 +15,13 @@ public class SaberClashEffectPatch : IAffinity
     }
 
     [AffinityPatch(typeof(SaberClashEffect), nameof(SaberClashEffect.Start))]
-    public void Postfix(ref SaberClashEffect instance)
+    public void Postfix(ref SaberClashEffect __instance)
     {
-        var glowEmissionModule = instance._glowParticleSystem.emission;
-        var sparkleEmissionModule = instance._sparkleParticleSystem.emission;
+        var glowEmissionModule = __instance._glowParticleSystem.emission;
+        var sparkleEmissionModule = __instance._sparkleParticleSystem.emission;
 
-        var glowMainModule = instance._glowParticleSystem.main;
-        var sparkleMainModule = instance._sparkleParticleSystem.main;
+        var glowMainModule = __instance._glowParticleSystem.main;
+        var sparkleMainModule = __instance._sparkleParticleSystem.main;
 
         if (!config.ClashGlow)
         {

--- a/ParticleOverdrive/UI/SettingsMenu.bsml
+++ b/ParticleOverdrive/UI/SettingsMenu.bsml
@@ -24,6 +24,7 @@
       <list-setting text='Explosion Particles' value='explosionParticleChoice' choices='explosionParticleChoices' formatter='multiplierFormatter' apply-on-change='true'/>
       <list-setting text='Explosion Particle Lifetime' value='explosionParticleLifetimeChoice' choices='lifetimeChoices' formatter='multiplierFormatter' apply-on-change='true'/>
       <list-setting text='Explosion Particle Size' value='explosionParticleSizeChoice' choices='lifetimeChoices' formatter='multiplierFormatter' apply-on-change='true'/>
+      <list-setting text='Explosion Particle Speed' value='explosionParticleSpeedChoice' choices='lifetimeChoices' formatter='multiplierFormatter' apply-on-change='true'/>
       <bool-setting text='Core Particles' value='noteCoreParticlesEnable' apply-on-change='true'/>
       <bool-setting text='Rainbow Particles' value='rainbowParticlesEnable' apply-on-change='true'/>
     </settings-container>

--- a/ParticleOverdrive/UI/SettingsMenu.cs
+++ b/ParticleOverdrive/UI/SettingsMenu.cs
@@ -87,6 +87,13 @@ public class SettingsMenu
         set => config.ExplosionParticleSizeMultiplier = value;
     }
 
+    [UIValue("explosionParticleSpeedChoice")]
+    public float ExplosionParticleSpeedMultiplier
+    {
+        get => config.ExplosionParticleSpeedMultiplier;
+        set => config.ExplosionParticleSpeedMultiplier = value;
+    }
+
     [UIValue("rainbowParticlesEnable")]
     public bool RainbowParticles
     {

--- a/ParticleOverdrive/UI/SettingsMenu.cs
+++ b/ParticleOverdrive/UI/SettingsMenu.cs
@@ -158,6 +158,15 @@ public class SettingsMenu
     private static readonly List<object> ParticleMultiplierChoicesList =
     [
         0f,
+        0.1f,
+        0.2f,
+        0.3f,
+        0.4f,
+        0.5f,
+        0.6f,
+        0.7f,
+        0.8f,
+        0.9f,
         1f,
         1.1f,
         1.2f,


### PR DESCRIPTION
Just a couple features I wanted for myself.
- Allow particle multiplier values between 0 and 1
- Add speed multiplier setting for explosion particles

Also renamed `instance` parameters back to `__instance`  since that was breaking the patches.
I can split into separate pull requests if you want.

The speed multiplier could probably be configurable for the other particle types as well, but I was only interested in changing it for the explosions.